### PR TITLE
2.52b

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 # Written and maintained by Michal Zalewski <lcamtuf@google.com>
 # 
-# Copyright 2013, 2014, 2015, 2016 Google Inc. All rights reserved.
+# Copyright 2013, 2014, 2015, 2016, 2017 Google Inc. All rights reserved.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,8 +111,8 @@ all_done: test_build
 .NOTPARALLEL: clean
 
 clean:
-	rm -f $(PROGS) afl-as as afl-g++ afl-clang afl-clang++ *.o *~ a.out core core.[1-9][0-9]* *.stackdump test .test test-instr .test-instr0 .test-instr1 qemu_mode/qemu-2.3.0.tar.bz2 afl-qemu-trace
-	rm -rf out_dir qemu_mode/qemu-2.3.0
+	rm -f $(PROGS) afl-as as afl-g++ afl-clang afl-clang++ *.o *~ a.out core core.[1-9][0-9]* *.stackdump test .test test-instr .test-instr0 .test-instr1 qemu_mode/qemu-2.10.0.tar.bz2 afl-qemu-trace
+	rm -rf out_dir qemu_mode/qemu-2.10.0
 	$(MAKE) -C llvm_mode clean
 	$(MAKE) -C libdislocator clean
 	$(MAKE) -C libtokencap clean

--- a/afl-showmap.c
+++ b/afl-showmap.c
@@ -4,7 +4,7 @@
 
    Written and maintained by Michal Zalewski <lcamtuf@google.com>
 
-   Copyright 2013, 2014, 2015, 2016 Google Inc. All rights reserved.
+   Copyright 2013, 2014, 2015, 2016, 2017 Google Inc. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -293,6 +293,8 @@ static void run_target(char** argv) {
 
     if (!getenv("LD_BIND_LAZY")) setenv("LD_BIND_NOW", "1", 0);
 
+    setsid();
+
     execv(target_path, argv);
 
     *(u32*)trace_bits = EXEC_FAIL_SIG;
@@ -556,6 +558,10 @@ static char** get_qemu_argv(u8* own_loc, char** argv, int argc) {
 
   char** new_argv = ck_alloc(sizeof(char*) * (argc + 4));
   u8 *tmp, *cp, *rsl, *own_copy;
+
+  /* Workaround for a QEMU stability glitch. */
+
+  setenv("QEMU_LOG", "nochain", 1);
 
   memcpy(new_argv + 3, argv + 1, sizeof(char*) * argc);
 

--- a/afl-tmin.c
+++ b/afl-tmin.c
@@ -4,7 +4,7 @@
 
    Written and maintained by Michal Zalewski <lcamtuf@google.com>
 
-   Copyright 2015, 2016 Google Inc. All rights reserved.
+   Copyright 2015, 2016, 2017 Google Inc. All rights reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -341,8 +341,11 @@ static u8 run_target(char** argv, u8* mem, u32 len, u8 first_run) {
   total_execs++;
 
   if (stop_soon) {
+
     SAYF(cRST cLRD "\n+++ Minimization aborted by user +++\n" cRST);
+    close(write_to_file(out_file, in_data, in_len));
     exit(1);
+
   }
 
   /* Always discard inputs that time out. */
@@ -890,6 +893,10 @@ static char** get_qemu_argv(u8* own_loc, char** argv, int argc) {
 
   char** new_argv = ck_alloc(sizeof(char*) * (argc + 4));
   u8 *tmp, *cp, *rsl, *own_copy;
+
+  /* Workaround for a QEMU stability glitch. */
+
+  setenv("QEMU_LOG", "nochain", 1);
 
   memcpy(new_argv + 3, argv + 1, sizeof(char*) * argc);
 

--- a/config.h
+++ b/config.h
@@ -21,7 +21,7 @@
 
 /* Version string: */
 
-#define VERSION             "2.51b"
+#define VERSION             "2.52b"
 
 /******************************************************
  *                                                    *

--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -17,6 +17,27 @@ is 2.41b. If you're stuck on an earlier release, it's strongly advisable
 to get on with the times.
 
 ---------------------------
+Version 2.52b (2017-11-04):
+---------------------------
+
+  - Upgraded QEMU patches from 2.3.0 to 2.10.0. Required troubleshooting
+    several weird issues. All the legwork done by Andrew Griffiths.
+
+  - Added setsid to afl-showmap. See the notes for 2.51b.
+
+  - Added target mode (deferred, persistent, qemu, etc) to fuzzer_stats.
+    Requested by Jakub Wilk.
+
+  - afl-tmin should now save a partially minimized file when Ctrl-C
+    is pressed. Suggested by Jakub Wilk.
+
+  - Added an option for afl-analyze to dump offsets in hex. Suggested by
+    Jakub Wilk.
+
+  - Added support for parameters in triage_crashes.sh. Patch by Adam of
+    DC949.
+
+---------------------------
 Version 2.51b (2017-08-30):
 ---------------------------
 

--- a/docs/env_variables.txt
+++ b/docs/env_variables.txt
@@ -213,7 +213,13 @@ to match when minimizing crashes. This will make minimization less useful, but
 may prevent the tool from "jumping" from one crashing condition to another in
 very buggy software. You probably want to combine it with the -e flag.
 
-7) Settings for libdislocator.so
+7) Settings for afl-analyze
+---------------------------
+
+You can set AFL_ANALYZE_HEX to get file offsets printed as hexadecimal instead
+of decimal.
+
+8) Settings for libdislocator.so
 --------------------------------
 
 The library honors three environmental variables:
@@ -233,14 +239,14 @@ The library honors three environmental variables:
     of the common allocators check for that internally and return NULL, so
     it's a security risk only in more exotic setups.
 
-8) Settings for libtokencap.so
+9) Settings for libtokencap.so
 ------------------------------
 
 This library accepts AFL_TOKEN_FILE to indicate the location to which the
 discovered tokens should be written.
 
-9) Third-party variables set by afl-fuzz & other tools
-------------------------------------------------------
+10) Third-party variables set by afl-fuzz & other tools
+-------------------------------------------------------
 
 Several variables are not directly interpreted by afl-fuzz, but are set to
 optimal values if not already present in the environment:

--- a/docs/status_screen.txt
+++ b/docs/status_screen.txt
@@ -297,7 +297,8 @@ wait a couple of cycles to get their chance).
 
 Next, we have the number of new paths found during this fuzzing section and
 imported from other fuzzer instances when doing parallelized fuzzing; and the
-number of inputs that produce seemingly variable behavior in the tested binary.
+extent to which identical inputs appear to sometimes produce variable behavior
+in the tested binary.
 
 That last bit is actually fairly interesting: it measures the consistency of
 observed traces. If a program always behaves the same for the same input data,

--- a/experimental/crash_triage/triage_crashes.sh
+++ b/experimental/crash_triage/triage_crashes.sh
@@ -5,7 +5,7 @@
 #
 # Written and maintained by Michal Zalewski <lcamtuf@google.com>
 #
-# Copyright 2013, 2014 Google Inc. All rights reserved.
+# Copyright 2013, 2014, 2017 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,18 +28,16 @@ echo
 ulimit -v 100000 2>/dev/null
 ulimit -d 100000 2>/dev/null
 
-if [ ! "$#" = "2" ]; then
-  echo "Usage: $0 /path/to/afl_output_dir /path/to/tested_binary" 1>&2
-  echo 1>&2
-  echo "Note: the tested binary must accept input on stdin and require no additional" 1>&2
-  echo "parameters. For more complex use cases, you need to edit this script." 1>&2
+if [ "$#" -lt "2" ]; then
+  echo "Usage: $0 /path/to/afl_output_dir /path/to/tested_binary [...target params...]" 1>&2
   echo 1>&2
   exit 1
 fi
 
 DIR="$1"
 BIN="$2"
-
+shift
+shift
 
 if [ "$AFL_ALLOW_TMP" = "" ]; then
 
@@ -85,11 +83,33 @@ for crash in $DIR/crashes/id:*; do
   id=`basename -- "$crash" | cut -d, -f1 | cut -d: -f2`
   sig=`basename -- "$crash" | cut -d, -f2 | cut -d: -f2`
 
+  # Grab the args, converting @@ to $crash
+
+  use_args=""
+  use_stdio=1
+
+  for a in $@; do
+
+    if [ "$a" = "@@" ] ; then
+      args="$use_args $crash"
+      unset use_stdio
+    else
+      args="$use_args $a"
+    fi
+
+  done
+
+  # Strip the trailing space
+  use_args="${use_args# }"
+
   echo "+++ ID $id, SIGNAL $sig +++"
   echo
 
-  $GDB --batch -q --ex "r <$crash" --ex 'back' --ex 'disass $pc, $pc+16' --ex 'info reg' --ex 'quit' "$BIN" 0</dev/null
+  if [ "$use_stdio" = "1" ]; then  
+    $GDB --batch -q --ex "r $use_args <$crash" --ex 'back' --ex 'disass $pc, $pc+16' --ex 'info reg' --ex 'quit' "$BIN" 0</dev/null
+  else
+    $GDB --batch -q --ex "r $use_args" --ex 'back' --ex 'disass $pc, $pc+16' --ex 'info reg' --ex 'quit' "$BIN" 0</dev/null
+  fi
   echo
 
 done
-

--- a/qemu_mode/README.qemu
+++ b/qemu_mode/README.qemu
@@ -21,7 +21,7 @@ The idea and much of the implementation comes from Andrew Griffiths.
 2) How to use
 -------------
 
-The feature is implemented with a fairly simple patch to QEMU 2.3.0. The
+The feature is implemented with a fairly simple patch to QEMU 2.10.0. The
 simplest way to build it is to run ./build_qemu_support.sh. The script will
 download, configure, and compile the QEMU binary for you.
 

--- a/qemu_mode/patches/cpu-exec.diff
+++ b/qemu_mode/patches/cpu-exec.diff
@@ -1,33 +1,28 @@
---- qemu-2.3.0/cpu-exec.c.orig     2014-12-09 14:45:40.000000000 +0000
-+++ qemu-2.3.0/cpu-exec.c  2015-02-20 22:07:02.966000000 +0000
-@@ -28,6 +28,8 @@
- #include "exec/memory-internal.h"
- #include "qemu/rcu.h"
-
+--- qemu-2.10.0-rc3-clean/accel/tcg/cpu-exec.c	2017-08-15 11:39:41.000000000 -0700
++++ qemu-2.10.0-rc3/accel/tcg/cpu-exec.c	2017-08-22 14:34:55.868730680 -0700
+@@ -36,6 +36,8 @@
+ #include "sysemu/cpus.h"
+ #include "sysemu/replay.h"
+ 
 +#include "../patches/afl-qemu-cpu-inl.h"
 +
  /* -icount align implementation. */
-
+ 
  typedef struct SyncClocks {
-@@ -296,8 +298,11 @@
-     }
-  not_found:
-    /* if no translated code available, then translate it now */
+@@ -144,6 +146,8 @@
+     int tb_exit;
+     uint8_t *tb_ptr = itb->tc_ptr;
+ 
++    AFL_QEMU_CPU_SNIPPET2;
 +
-     tb = tb_gen_code(cpu, pc, cs_base, flags, 0);
-
-+    AFL_QEMU_CPU_SNIPPET1;
-+
-  found:
-     /* Move the last found TB to the head of the list */
-     if (likely(*ptb1)) {
-@@ -492,6 +497,9 @@
-                     next_tb = 0;
-                     tcg_ctx.tb_ctx.tb_invalidated_flag = 0;
-                 }
-+
-+                AFL_QEMU_CPU_SNIPPET2;
-+
-                 if (qemu_loglevel_mask(CPU_LOG_EXEC)) {
-                     qemu_log("Trace %p [" TARGET_FMT_lx "] %s\n",
-                              tb->tc_ptr, tb->pc, lookup_symbol(tb->pc));
+     qemu_log_mask_and_addr(CPU_LOG_EXEC, itb->pc,
+                            "Trace %p [%d: " TARGET_FMT_lx "] %s\n",
+                            itb->tc_ptr, cpu->cpu_index, itb->pc,
+@@ -365,6 +369,7 @@
+             if (!tb) {
+                 /* if no translated code available, then translate it now */
+                 tb = tb_gen_code(cpu, pc, cs_base, flags, 0);
++                AFL_QEMU_CPU_SNIPPET1;
+             }
+ 
+             mmap_unlock();

--- a/qemu_mode/patches/elfload.diff
+++ b/qemu_mode/patches/elfload.diff
@@ -1,6 +1,6 @@
---- qemu-2.3.0/linux-user/elfload.c.orig	2014-12-09 14:45:42.000000000 +0000
-+++ qemu-2.3.0/linux-user/elfload.c	2015-01-28 02:51:23.719000000 +0000
-@@ -28,6 +28,8 @@
+--- qemu-2.10.0-rc3-clean/linux-user/elfload.c	2017-08-15 11:39:41.000000000 -0700
++++ qemu-2.10.0-rc3/linux-user/elfload.c	2017-08-22 14:33:57.397127516 -0700
+@@ -20,6 +20,8 @@
  
  #define ELF_OSABI   ELFOSABI_SYSV
  
@@ -9,7 +9,7 @@
  /* from personality.h */
  
  /*
-@@ -1889,6 +1891,8 @@
+@@ -2085,6 +2087,8 @@
      info->brk = 0;
      info->elf_flags = ehdr->e_flags;
  
@@ -18,7 +18,7 @@
      for (i = 0; i < ehdr->e_phnum; i++) {
          struct elf_phdr *eppnt = phdr + i;
          if (eppnt->p_type == PT_LOAD) {
-@@ -1922,9 +1926,11 @@
+@@ -2118,9 +2122,11 @@
              if (elf_prot & PROT_EXEC) {
                  if (vaddr < info->start_code) {
                      info->start_code = vaddr;

--- a/qemu_mode/patches/syscall.diff
+++ b/qemu_mode/patches/syscall.diff
@@ -1,25 +1,35 @@
---- qemu-2.3.0/linux-user/syscall.c.orig	2014-12-09 14:45:43.000000000 +0000
-+++ qemu-2.3.0/linux-user/syscall.c	2015-03-27 06:33:00.736000000 +0000
-@@ -227,7 +227,21 @@
- _syscall3(int,sys_rt_sigqueueinfo,int,pid,int,sig,siginfo_t *,uinfo)
- _syscall3(int,sys_syslog,int,type,char*,bufp,int,len)
- #if defined(TARGET_NR_tgkill) && defined(__NR_tgkill)
--_syscall3(int,sys_tgkill,int,tgid,int,pid,int,sig)
-+
+--- qemu-2.10.0-rc3-clean/linux-user/syscall.c	2017-08-15 11:39:41.000000000 -0700
++++ qemu-2.10.0-rc3/linux-user/syscall.c	2017-08-22 14:34:03.193088186 -0700
+@@ -116,6 +116,8 @@
+ 
+ #include "qemu.h"
+ 
 +extern unsigned int afl_forksrv_pid;
 +
-+static int sys_tgkill(int tgid, int pid, int sig) {
-+
-+  /* Workaround for -lpthread to make abort() work properly, without
-+     killing the forkserver due to a prematurely cached PID. */
-+
-+  if (afl_forksrv_pid && afl_forksrv_pid == pid && sig == SIGABRT)
-+    pid = tgid = getpid();
-+
-+  return syscall(__NR_sys_tgkill, pid, tgid, sig);
-+
-+}
-+
+ #ifndef CLONE_IO
+ #define CLONE_IO                0x80000000      /* Clone io context */
  #endif
- #if defined(TARGET_NR_tkill) && defined(__NR_tkill)
- _syscall2(int,sys_tkill,int,tid,int,sig)
+@@ -11688,8 +11690,21 @@
+         break;
+ 
+     case TARGET_NR_tgkill:
+-        ret = get_errno(safe_tgkill((int)arg1, (int)arg2,
+-                        target_to_host_signal(arg3)));
++
++        {
++          int pid  = (int)arg1,
++              tgid = (int)arg2,
++              sig  = (int)arg3;
++
++          /* Not entirely sure if the below is correct for all architectures. */
++
++          if(afl_forksrv_pid && afl_forksrv_pid == pid && sig == SIGABRT)
++              pid = tgid = getpid();
++
++          ret = get_errno(safe_tgkill(pid, tgid, target_to_host_signal(sig)));
++
++        }
++
+         break;
+ 
+ #ifdef TARGET_NR_set_robust_list


### PR DESCRIPTION
  - Upgraded QEMU patches from 2.3.0 to 2.10.0. Required troubleshooting
    several weird issues. All the legwork done by Andrew Griffiths.

  - Added setsid to afl-showmap. See the notes for 2.51b.

  - Added target mode (deferred, persistent, qemu, etc) to fuzzer_stats.
    Requested by Jakub Wilk.

  - afl-tmin should now save a partially minimized file when Ctrl-C
    is pressed. Suggested by Jakub Wilk.

  - Added an option for afl-analyze to dump offsets in hex. Suggested by
    Jakub Wilk.

  - Added support for parameters in triage_crashes.sh. Patch by Adam of
    DC949.